### PR TITLE
Function eval for vae

### DIFF
--- a/lib/layers/odefunc.py
+++ b/lib/layers/odefunc.py
@@ -274,6 +274,9 @@ class ODEfunc(nn.Module):
         self._e = e
         self._num_evals.fill_(0)
 
+    def num_evals(self):
+        return self._num_evals.item()
+
     def forward(self, t, states):
         assert len(states) >= 2
         y = states[0]

--- a/train_misc.py
+++ b/train_misc.py
@@ -59,7 +59,7 @@ def count_nfe(model):
             self.num_evals = 0
 
         def __call__(self, module):
-            else isinstance(module, layers.ODEfunc):
+            if isinstance(module, layers.ODEfunc):
                 self.num_evals += module.num_evals()
 
     accumulator = AccNumEvals()

--- a/train_misc.py
+++ b/train_misc.py
@@ -59,9 +59,7 @@ def count_nfe(model):
             self.num_evals = 0
 
         def __call__(self, module):
-            if isinstance(module, layers.CNF):
-                self.num_evals += module.num_evals()
-            elif isinstance(module, layers.ODEfunc):
+            else isinstance(module, layers.ODEfunc):
                 self.num_evals += module.num_evals()
 
     accumulator = AccNumEvals()

--- a/train_misc.py
+++ b/train_misc.py
@@ -61,6 +61,8 @@ def count_nfe(model):
         def __call__(self, module):
             if isinstance(module, layers.CNF):
                 self.num_evals += module.num_evals()
+            elif isinstance(module, layers.ODEfunc):
+                self.num_evals += module.num_evals()
 
     accumulator = AccNumEvals()
     model.apply(accumulator)


### PR DESCRIPTION
When using flow={'cnf_bias, cnf_hyper, cnf_lyper, cnf_rank} in train_vae_flow.py the number of function evaluations is 0 for both forward and backward computation. This request will fix the issues by checking if instance is layers.ODEfunc instead of layers.CNF (which is just called when flow='cnf') in count_nfe().